### PR TITLE
Update with mDNS support

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -19,7 +19,6 @@
 //      Parameter Name              Value   Default  Notes                                                                      Hint
 // OPERATIONAL MODE ----------------------------------------------------------------------------------------------------------------
 #define OPERATIONAL_MODE             WIFI //   WIFI, Or use ETHERNET_W5100 or ETHERNET_W5500                                 <-Req'd
-#define MDNS_NAME                "onstep" //   "onstep", mDNS device name                                                           Adjust
 
 // SERIAL PORTS --------------------------------------------------------------------------------------------------------------------
 #define SERIAL_BAUD_DEFAULT          9600 //   9600, Common baud rates for this parameter are 9600,19200,57600,115200,etc.    Infreq

--- a/Config.h
+++ b/Config.h
@@ -19,6 +19,7 @@
 //      Parameter Name              Value   Default  Notes                                                                      Hint
 // OPERATIONAL MODE ----------------------------------------------------------------------------------------------------------------
 #define OPERATIONAL_MODE             WIFI //   WIFI, Or use ETHERNET_W5100 or ETHERNET_W5500                                 <-Req'd
+#define MDNS_NAME                "onstep" //   "onstep", mDNS device name                                                           Adjust
 
 // SERIAL PORTS --------------------------------------------------------------------------------------------------------------------
 #define SERIAL_BAUD_DEFAULT          9600 //   9600, Common baud rates for this parameter are 9600,19200,57600,115200,etc.    Infreq

--- a/Extended.config.h
+++ b/Extended.config.h
@@ -31,6 +31,7 @@
 // PASSWORD ------------------------------------------------------------------------------------------------------------------------
 #define PASSWORD_DEFAULT       "password" //  "password", Adjust as required, this can be changed at runtime also.            Adjust
                                           //              password for runtime access to network settings.
+#define MDNS_NAME                "onstep" //   "onstep",  mDNS device name                                                           Adjust
 
 // BLE GAMEPAD SETTINGS (ESP32 ONLY) ------------------------------------------------ see https://onstep.groups.io/g/main/wiki/26762
 #define BLE_GAMEPAD                   OFF //         OFF, ON to allow BLE gamepad connection for ESP32 only.                  Option

--- a/src/lib/wifi/WifiManager.cpp
+++ b/src/lib/wifi/WifiManager.cpp
@@ -120,6 +120,8 @@ bool WifiManager::init() {
       active = true;
       VLF("MSG: WiFi, initialized");
 
+      if (MDNS.begin(MDNS_NAME)) { VLF("MSG: mDNS started"); }
+
       #if STA_AUTO_RECONNECT == true
         if (settings.stationEnabled) {
           VF("MSG: WiFi, start connection check task (rate 8s priority 7)... ");

--- a/src/lib/wifi/WifiManager.h
+++ b/src/lib/wifi/WifiManager.h
@@ -15,10 +15,12 @@
   #include <WiFi.h>
   #include <WiFiClient.h>
   #include <WiFiAP.h>
+  #include <ESPmDNS.h>
 #elif defined(ESP8266)
   #include <ESP8266WiFi.h>
   #include <WiFiClient.h>
   #include <ESP8266WiFiAP.h>
+  #include <ESP8266mDNS.h>
 #else
   #error "Configuration (Config.h): No Wifi support is present for this device"
 #endif


### PR DESCRIPTION
A simple deployment of mDNS allows accessing OnStep controller in a network with a user friendly DNS name instead of IP address. The host mDNS name is configurable while domain part depends on the network - usually it would be .local. Avahi / Bonjour daemons in Windows 10/11, Mac OS X and most Linux distributions work fine with this mDNS implementation.

Smart Web Server works well in both modes (access point and station) - tested on ESP32 and ESP32C3 in version 2.06k with Windows 10, Windows 11, Mac OS X and Ubuntu 22.04.

(known issue) Unfortunately, this deployment of mDNS doesn't work properly in SWS based on ESP8266 - as of now unsupported, might need to be further investigated.
