### PR TITLE
Fix Slew Button spacing on firefox

### DIFF
--- a/src/pages/mount/GuideTile.h
+++ b/src/pages/mount/GuideTile.h
@@ -11,12 +11,13 @@ extern void guideTileAjax(String &data);
 extern void guideTileGet();
 
 const char html_guidePad[] PROGMEM =
-"<button class='gb' onpointerdown=\"g('n1')\" onpointerup=\"g('n0')\" type='button'>" BUTTON_N "</button><br />"
-"<button class='gb' onpointerdown=\"g('e1')\" onpointerup=\"g('e0')\" type='button'>" BUTTON_E "</button>"
-"<button class='gb' onpointerdown=\"g('sy')\" title='Sync' type='button'>" BUTTON_SYNC "</button>"
-"<button class='gb' onpointerdown=\"g('w1')\" onpointerup=\"g('w0')\" type='button'>" BUTTON_W "</button><br />"
-"<button class='gb' onpointerdown=\"g('s1')\" onpointerup=\"g('s0')\" type='button'>" BUTTON_S "</button><br />";
-
+"<div style=\"display: grid;grid-template-rows: repeat(3, 50px);grid-template-columns: repeat(3, 60px);justify-content: center;align-items: center;gap: 10px;\">"
+"<button class='gb' onpointerdown=\"g('n1')\" onpointerup=\"g('n0')\" type='button' style=\"grid-row: 1;grid-column: 2;\">" BUTTON_N "</button><br />"
+"<button class='gb' onpointerdown=\"g('e1')\" onpointerup=\"g('e0')\" type='button' style=\"grid-row: 2;grid-column: 3;\">" BUTTON_E "</button>"
+"<button class='gb' onpointerdown=\"g('sy')\" title='Sync' type='button' style=\"grid-row: 2;grid-column: 2;\">" BUTTON_SYNC "</button>"
+"<button class='gb' onpointerdown=\"g('w1')\" onpointerup=\"g('w0')\" type='button' style=\"grid-row: 2;grid-column: 1;\">" BUTTON_W "</button><br />"
+"<button class='gb' onpointerdown=\"g('s1')\" onpointerup=\"g('s0')\" type='button' style=\"grid-row: 3;grid-column: 2;\">" BUTTON_S "</button><br />"
+"</div>";
 const char html_guidePulseRates[] PROGMEM =
 "<button id='guide_r0' class='btns_right' onpointerdown=\"g('R0')\" type='button'>0.25</button>"
 "<button id='guide_r1' class='btns_mid' onpointerdown=\"g('R1')\" type='button'>0.5</button>"


### PR DESCRIPTION
The slew buttons were not correctly aligned in Firefox.
Before:
![Screenshot From 2024-11-20 20-11-03](https://github.com/user-attachments/assets/254fd379-8121-48c5-9dba-a19dbc2de2be)
After:
![Screenshot From 2024-11-20 20-41-36](https://github.com/user-attachments/assets/1a43a382-b76f-463c-9de5-927a7b226b0b)
