### PR TITLE
Remove restrictive horizon limits for fork mounts

### DIFF
--- a/src/pages/mount/LimitsTile.cpp
+++ b/src/pages/mount/LimitsTile.cpp
@@ -71,12 +71,20 @@ void limitsTile(String &data)
 
   data.concat(F("<br />Limits:<br />"));
 
-  // Overhead and Horizon Limits
-  sprintf_P(temp, html_configMinAlt, minAlt);
-  data.concat(temp);
-
-  sprintf_P(temp, html_configMaxAlt, maxAlt);
-  data.concat(temp);
+  // Overhead and Horizon Limits - Conditional restrictions for fork mounts
+  if (status.mountType == MT_FORK) {
+    // Fork mounts: No restrictions on horizon limits
+    sprintf_P(temp, html_configMinAlt, minAlt);
+    data.concat(temp);
+    sprintf_P(temp, html_configMaxAlt, maxAlt);
+    data.concat(temp);
+  } else {
+    // Other mount types: Use restricted limits
+    sprintf_P(temp, html_configMinAltRestricted, minAlt);
+    data.concat(temp);
+    sprintf_P(temp, html_configMaxAltRestricted, maxAlt);
+    data.concat(temp);
+  }
 
   // Meridian Limits
   if (status.mountType == MT_GEM)
@@ -112,25 +120,39 @@ extern void limitsTileGet()
   String v;
   char temp[80];
 
-  // Overhead limit
+  // Overhead limit - Conditional restrictions for fork mounts
   v = www.arg("ol");
   if (!v.equals(EmptyStr))
   {
-    if (v.toInt() >= 60 && v.toInt() <= 90)
-    {
+    if (status.mountType == MT_FORK) {
+      // Fork mounts: No restrictions
       sprintf(temp, ":So%d#", (int16_t)v.toInt());
       onStep.commandBool(temp);
+    } else {
+      // Other mount types: Apply restrictions
+      if (v.toInt() >= 60 && v.toInt() <= 90)
+      {
+        sprintf(temp, ":So%d#", (int16_t)v.toInt());
+        onStep.commandBool(temp);
+      }
     }
   }
 
-  // Horizon limit
+  // Horizon limit - Conditional restrictions for fork mounts
   v = www.arg("hl");
   if (!v.equals(EmptyStr))
   {
-    if (v.toInt() >= -30 && v.toInt() <= 30)
-    {
+    if (status.mountType == MT_FORK) {
+      // Fork mounts: No restrictions
       sprintf(temp, ":Sh%d#", (int16_t)v.toInt());
       onStep.commandBool(temp);
+    } else {
+      // Other mount types: Apply restrictions
+      if (v.toInt() >= -30 && v.toInt() <= 30)
+      {
+        sprintf(temp, ":Sh%d#", (int16_t)v.toInt());
+        onStep.commandBool(temp);
+      }
     }
   }
 

--- a/src/pages/mount/LimitsTile.h
+++ b/src/pages/mount/LimitsTile.h
@@ -14,11 +14,18 @@ extern void limitsTileGet();
 const char html_configFormBegin[] PROGMEM = "<div class='content'><br />\n<form method='get' action='/configuration.htm'>";
 const char html_configFormEnd[] PROGMEM = "\n</form><br />\n</div><br />\n";
 
-// Overhead and Horizon limits
+// Overhead and Horizon limits - CONDITIONAL RESTRICTIONS FOR FORK MOUNTS
 const char html_configMinAlt[] PROGMEM =
-  "<input value='%d' type='number' name='hl' min='-30' max='30'>&nbsp;" L_LIMITS_RANGE_HORIZON "<br />\n";
+  "<input value='%d' type='number' name='hl'>&nbsp;" L_LIMITS_RANGE_HORIZON "<br />\n";
 
 const char html_configMaxAlt[] PROGMEM =
+  "<input value='%d' type='number' name='ol'>&nbsp;" L_LIMITS_RANGE_OVERHEAD "<br />\n";
+
+// Original restricted versions for non-fork mounts
+const char html_configMinAltRestricted[] PROGMEM =
+  "<input value='%d' type='number' name='hl' min='-30' max='30'>&nbsp;" L_LIMITS_RANGE_HORIZON "<br />\n";
+
+const char html_configMaxAltRestricted[] PROGMEM =
   "<input value='%d' type='number' name='ol' min='60' max='90'>&nbsp;" L_LIMITS_RANGE_OVERHEAD "<br />\n";
 
 const char html_configBlAxis1[] PROGMEM =

--- a/src/pages/mount/LimitsTile.h
+++ b/src/pages/mount/LimitsTile.h
@@ -16,10 +16,10 @@ const char html_configFormEnd[] PROGMEM = "\n</form><br />\n</div><br />\n";
 
 // Overhead and Horizon limits - CONDITIONAL RESTRICTIONS FOR FORK MOUNTS
 const char html_configMinAlt[] PROGMEM =
-  "<input value='%d' type='number' name='hl'>&nbsp;" L_LIMITS_RANGE_HORIZON "<br />\n";
+  "<input value='%d' type='number' name='hl'>&nbsp;Horizon, min altitude &pm;90&deg;<br />\n";
 
 const char html_configMaxAlt[] PROGMEM =
-  "<input value='%d' type='number' name='ol'>&nbsp;" L_LIMITS_RANGE_OVERHEAD "<br />\n";
+  "<input value='%d' type='number' name='ol'>&nbsp;Overhead, max altitude &pm;90&deg;<br />\n";
 
 // Original restricted versions for non-fork mounts
 const char html_configMinAltRestricted[] PROGMEM =


### PR DESCRIPTION
## Summary
Removes restrictive horizon and overhead limit validation for fork mounts in the web interface.

## Changes
- **LimitsTile.h**: Added conditional HTML templates - fork mounts show "±90°" guidance, others show restrictive ranges
- **LimitsTile.cpp**: Added conditional validation logic - fork mounts bypass server-side validation, others maintain restrictions
- **Detection**: Uses `status.mountType == MT_FORK` to detect fork mounts via OnStep `:GU#` command

## Rationale
**Safety Critical**: Fork mounts require the ability to park at -90° declination (pointing straight down) at the meridian to protect the scope from hitting the mount. The current restrictive limits (-30° to +30°) prevent this essential safety position, potentially causing damage to the telescope.

Fork mounts can safely move through the full altitude range from horizon to horizon (-90° to +90°), unlike equatorial mounts which have mechanical limitations requiring restrictive limits.

## Related Changes
This web interface change requires corresponding changes in OnStepX firmware to remove command processing restrictions. See related OnStepX PR: https://github.com/hjd1964/OnStepX/pull/97

## Testing
- Fork mounts: Accept any horizon/overhead limit values, show ±90° guidance
- Other mounts: Maintain original restrictive validation and guidance
